### PR TITLE
PDF Page Count Validation Feature Implementation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,8 @@
         "globals": "^15.15.0",
         "jest": "^29.7.0",
         "jest-mock-req-res": "^1.0.2",
+        "pdf-lib": "^1.17.1",
+        "pdfjs-dist": "^3.11.174",
         "sqlite3": "^5.1.7",
         "supertest": "^7.0.0"
       }
@@ -1372,6 +1374,182 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2001,6 +2179,24 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "dev": true,
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "dev": true,
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3186,6 +3382,60 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/canvas/node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/canvas/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/canvas/node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -6683,6 +6933,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -6735,6 +6992,27 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",
@@ -6992,6 +7270,12 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7093,6 +7377,47 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+    },
+    "node_modules/path2d-polyfill": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
+      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "dev": true,
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "3.11.174",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^2.11.2",
+        "path2d-polyfill": "^2.0.1"
+      }
     },
     "node_modules/pg-connection-string": {
       "version": "2.7.0",
@@ -8608,6 +8933,13 @@
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg=="
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -8855,6 +9187,24 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,8 @@
     "globals": "^15.15.0",
     "jest": "^29.7.0",
     "jest-mock-req-res": "^1.0.2",
+    "pdf-lib": "^1.17.1",
+    "pdfjs-dist": "^3.11.174",
     "sqlite3": "^5.1.7",
     "supertest": "^7.0.0"
   },

--- a/backend/src/controllers/financialDocumentController.js
+++ b/backend/src/controllers/financialDocumentController.js
@@ -61,6 +61,7 @@ class FinancialDocumentController {
         await pdfValidationService.validatePdfPageCount(buffer);
         
       } catch (error) {
+        console.error("PDF Validation Error:", error); 
         if (error.message === "PDF has no pages.") {
             return safeResponse(res, 400, "PDF has no pages.");
         }

--- a/backend/src/controllers/financialDocumentController.js
+++ b/backend/src/controllers/financialDocumentController.js
@@ -27,7 +27,7 @@ class FinancialDocumentController {
       if (res.headersSent) return; //  Prevent sending a duplicate response
 
       if (req.query && req.query.simulateTimeout === "true") {
-        return safeResponse(res, 504, "Server timeout - upload processing timed out");
+        return safeResponse(res, 504, "Server timeout - upload processing timed out" );
 
       }
       if (!req.user) {
@@ -43,65 +43,83 @@ class FinancialDocumentController {
       
       try {
         await this.executeWithTimeout(async () => {
-          // File type validation
-          try {
-            await pdfValidationService.validatePDF(buffer, mimetype, originalname);
-          } catch (error) {
-            return safeResponse(res, 415, "File format is not PDF");
-          }
-  
-          // Encryption check
-          const isEncrypted = await pdfValidationService.isPdfEncrypted(buffer);
-          if (isEncrypted) {
-            return safeResponse(res, 400, "PDF is encrypted");
-          }
-  
-          // Integrity check
-          const isValidPdf = await pdfValidationService.checkPdfIntegrity(buffer);
-          if (!isValidPdf) {
-            return safeResponse(res, 400, "PDF file is invalid");
-          }
-  
-          // File size validation
-          try {
-            await pdfValidationService.validateSizeFile(buffer);
-          } catch (error) {
-            return safeResponse(res, 413, "File size exceeds maximum limit");
-          }
-          try{
-            let result;
-            if (this.documentType === "Invoice") {
-                result = await this.service.uploadInvoice({
-                    originalname, buffer, mimetype, partnerId,
-                });
-                return safeResponse(res, 200, result);
-            } 
-            else if (this.documentType === "Purchase Order") {
-                result = await this.service.uploadPurchaseOrder({
-                    originalname, buffer, mimetype, partnerId,
-                });
-                return safeResponse(res, 200, result);
-            }
-            else{
-              throw new Error("document type unknown")
-            }
-          }catch(error){
-            console.error("Unhandled error in upload process:", error);
-            if(error.message === "document type unknown"){
-              return safeResponse(res, 400, "Invalid document type provided" );
-            }
-            return safeResponse(res, 500, "Internal server error");
-          }
-        });
-      } catch (error) {
-        if (error.message === "Timeout") {
-          return safeResponse(res, 504, "Server timeout - upload processing timed out");
+        // File type validation
+        try {
+          await pdfValidationService.validatePDF(buffer, mimetype, originalname);
+        } catch (error) {
+          return safeResponse(res, 415, "File format is not PDF");
         }
-        console.error("Unexpected error:", error);
-        return safeResponse(res, 500, "Internal server error");
+
+        // Encryption check
+        const isEncrypted = await pdfValidationService.isPdfEncrypted(buffer);
+        if (isEncrypted) {
+          return safeResponse(res, 400, "PDF is encrypted");
+        }
+
+      // Page count validation
+      try {
+        await pdfValidationService.validatePdfPageCount(buffer);
+        
+      } catch (error) {
+        if (error.message === "PDF has no pages.") {
+            return safeResponse(res, 400, "PDF has no pages.");
+        }
+
+        if (error.message === "PDF exceeds the maximum allowed pages (100).") {
+            return safeResponse(res, 400, "PDF exceeds the maximum allowed pages (100).");
+        }
+
+        return safeResponse(res, 400, "Failed to determine PDF page count.");
       }
+
+        
+  
+        // Integrity check
+        const isValidPdf = await pdfValidationService.checkPdfIntegrity(buffer);
+        if (!isValidPdf) {
+          return safeResponse(res, 400, "PDF file is invalid");
+        }
+
+        // File size validation
+        try {
+          await pdfValidationService.validateSizeFile(buffer);
+        } catch (error) {
+          return safeResponse(res, 413, "File size exceeds maximum limit");
+        }
+        try{
+          let result;
+          if (this.documentType === "Invoice") {
+            result = await this.service.uploadInvoice({
+                originalname, buffer, mimetype, partnerId,
+            });
+            return safeResponse(res, 200, result);
+          } 
+          else if (this.documentType === "Purchase Order") {
+            result = await this.service.uploadPurchaseOrder({
+                originalname, buffer, mimetype, partnerId,
+            });
+            return safeResponse(res, 200, result);
+          }
+          else{
+            throw new Error("document type unknown")
+          }
+        }catch(error){
+          console.error("Unhandled error in upload process:", error);
+          if(error.message === "document type unknown"){
+            return safeResponse(res, 400, "Invalid document type provided" );
+          }
+          return safeResponse(res, 500, "Internal server error");
+        }
+      });
+    } catch (error) {
+      if (error.message === "Timeout") {
+        return safeResponse(res, 504, "Server timeout - upload processing timed out");
+      }
+      console.error("Unexpected error:", error);
+      return safeResponse(res, 500, "Internal server error");
     }
   }
+}
   
-  module.exports = FinancialDocumentController;
+module.exports = FinancialDocumentController;
   

--- a/backend/src/services/pdfValidationService.js
+++ b/backend/src/services/pdfValidationService.js
@@ -116,7 +116,9 @@ class PdfValidationService {
      */
     async validatePdfPageCount(fileBuffer) {
         try {
-            const loadingTask = pdfjsLib.getDocument({ data: fileBuffer });
+            const uint8ArrayBuffer = new Uint8Array(fileBuffer);
+
+            const loadingTask = pdfjsLib.getDocument({ data: uint8ArrayBuffer });
             const pdfDocument = await loadingTask.promise;
             const pageCount = pdfDocument.numPages;
 

--- a/backend/src/services/pdfValidationService.js
+++ b/backend/src/services/pdfValidationService.js
@@ -1,5 +1,6 @@
 console.log("Loading pdfValidationService.js at path:", __filename);
 const path = require("path");
+const pdfjsLib = require("pdfjs-dist");
 
 class PdfValidationService {
     /**
@@ -102,6 +103,39 @@ class PdfValidationService {
         const matches = regex.exec(startXrefSection);
 
         return !!(matches?.[1] && /\d{1,10} \d{1,10} obj/.test(content));
+    }
+
+    /**
+     * Validates the number of pages in a PDF file.
+     * 
+     * This function ensures that the PDF has at least 1 page 
+     * and does not exceed 100 pages.
+     * 
+     * @param {Buffer} fileBuffer - Buffer containing the PDF file data
+     * @returns {Promise<boolean>} - Returns true if the PDF has a valid page count
+     * @throws {Error} - Throws an error if the PDF is empty or exceeds the limit
+     */
+    async validatePdfPageCount(fileBuffer) {
+        try {
+            const loadingTask = pdfjsLib.getDocument({ data: fileBuffer });
+            const pdfDocument = await loadingTask.promise;
+            const pageCount = pdfDocument.numPages;
+
+            if (pageCount === 0) {
+                throw new Error("PDF has no pages.");
+            }
+
+            if (pageCount > 100) {
+                throw new Error("PDF exceeds the maximum allowed pages (100).");
+            }
+
+            return true;
+        } catch (error) {
+            if (error.message === "PDF has no pages." || error.message === "PDF exceeds the maximum allowed pages (100).") {
+                throw error;
+            }
+            throw new Error("Failed to read PDF page count.");
+        }
     }
 }
 

--- a/backend/src/services/pdfValidationService.js
+++ b/backend/src/services/pdfValidationService.js
@@ -1,4 +1,3 @@
-console.log("Loading pdfValidationService.js at path:", __filename);
 const path = require("path");
 const pdfjsLib = require("pdfjs-dist");
 


### PR DESCRIPTION
This PR implements a PDF page count validation feature for invoice uploads using Test-Driven Development (TDD) methodology. The implementation ensures that uploaded PDF files have at least one page and do not exceed 100 pages, improving reliability and preventing issues with empty or oversized documents.
Changes Made

Added PDF validation service function - Implemented validatePdfPageCount() method that verifies PDFs have 1-100 pages
Updated controller logic - Enhanced error handling in the upload controller to return appropriate status codes and error messages based on validation results
Implemented comprehensive test cases - Created three test scenarios to ensure all validation paths work correctly:

Testing for empty PDFs (0 pages)
Testing for oversized PDFs (>100 pages)
Testing for general PDF parsing errors